### PR TITLE
feat: Add Google Cloud Run deployment configuration

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,44 @@
+# This file tells gcloud CLI to ignore these files and directories when
+# uploading source to Google Cloud. This is especially important for
+# `gcloud builds submit` and `gcloud app deploy`.
+
+# Python virtual environment
+venv/
+*.pyenv
+
+# Python bytecode and cache
+*.pyc
+__pycache__/
+
+# Git directory and related files
+.git/
+.gitignore
+.gitattributes
+
+# IDE and editor specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Local instance/config files (if any)
+instance/
+*.local
+*.db # If using local SQLite for testing, for example
+
+# Docker related files if building locally first (though Dockerfile itself IS needed)
+# For `gcloud builds submit`, the Docker context is uploaded, so Dockerfile is included.
+# If you had other local Docker build artifacts, you might list them.
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Test files and directories (if not needed in the deployed app)
+# tests/
+# *.test.py
+# pytest.ini
+# .coveragerc
+
+# README.md is often fine to include, but can be ignored if large or not needed.
+# README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install system dependencies that might be needed by some Python packages
+# (though likely not strictly necessary for this simple Flask app)
+# RUN apt-get update && apt-get install -y --no-install-recommends gcc #     && rm -rf /var/lib/apt/lists/*
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code into the container at /app
+COPY . .
+
+# Expose the port Gunicorn will run on (Cloud Run sets this via PORT env var)
+# EXPOSE 8080 # Not strictly needed for Cloud Run as it uses the PORT env var
+
+# Define the command to run the application using Gunicorn
+# Cloud Run provides the PORT environment variable, so Gunicorn should listen on that port.
+# The default host 0.0.0.0 makes it accessible from outside the container.
+# app:app refers to the 'app' Flask instance in 'app.py'.
+CMD exec gunicorn --bind 0.0.0.0:$PORT app:app

--- a/README.md
+++ b/README.md
@@ -49,3 +49,58 @@ This is a web-based text arcade shooter game, reminiscent of Space Invaders, ser
     [http://127.0.0.1:5000/](http://127.0.0.1:5000/)
 
 The game should now be running in your browser.
+
+## Deploying to Google Cloud Run
+
+These instructions guide you through deploying the JS Invaders Flask application to Google Cloud Run using the provided `deploy.sh` script.
+
+### Prerequisites
+
+1.  **Google Cloud SDK (`gcloud` CLI)**: Ensure you have the `gcloud` CLI installed and initialized.
+    *   [Installation Guide](https://cloud.google.com/sdk/docs/install)
+    *   Initialize: `gcloud init`
+
+2.  **Google Cloud Project**:
+    *   Create a new Google Cloud Project or use an existing one.
+    *   Ensure **Billing is enabled** for your project.
+    *   Note your **Project ID**.
+
+3.  **Enable APIs**: The `deploy.sh` script attempts to enable the required APIs (Cloud Build, Cloud Run, Container Registry/Artifact Registry). However, you might need to do this manually if you encounter permission issues:
+    *   Cloud Build API
+    *   Cloud Run API
+    *   Container Registry API (or Artifact Registry API if you modify the script)
+    You can enable these in the Google Cloud Console under "APIs & Services".
+
+4.  **Permissions**: Ensure the authenticated `gcloud` user has sufficient permissions to manage Cloud Build, Container Registry/Artifact Registry, and Cloud Run (e.g., roles like "Cloud Build Editor", "Storage Admin" for GCR/Artifact Registry, "Cloud Run Admin", "Service Account User").
+
+5.  **Docker (Optional, for local building/testing)**: While Cloud Build is used for deployment, having Docker installed locally can be useful for testing the `Dockerfile` if needed.
+
+### Deployment Steps
+
+1.  **Set Project ID in `deploy.sh` (if not using gcloud config)**:
+    *   Open the `deploy.sh` script.
+    *   Locate the line `PROJECT_ID=""`.
+    *   Replace `""` with your actual Google Cloud Project ID.
+    *   Alternatively, ensure your `gcloud` CLI is configured with the correct project: `gcloud config set project YOUR_PROJECT_ID`. The script will attempt to use this if `PROJECT_ID` is not set in the script.
+
+2.  **Make the script executable:**
+    ```bash
+    chmod +x deploy.sh
+    ```
+
+3.  **Run the deployment script:**
+    ```bash
+    ./deploy.sh
+    ```
+
+4.  **Access the application:**
+    *   After the script completes successfully, it will output the URL of your deployed Cloud Run service.
+    *   Open this URL in your web browser to access the JS Invaders game.
+
+### Notes
+
+*   The `deploy.sh` script uses Google Container Registry (`gcr.io`) by default. If you prefer to use Artifact Registry, you will need to:
+    1.  Enable the Artifact Registry API.
+    2.  Create an Artifact Registry Docker repository.
+    3.  Update the `IMAGE_NAME` variable in `deploy.sh` to point to your Artifact Registry repository (e.g., `REGION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/SERVICE_NAME`).
+*   The service is deployed with `--allow-unauthenticated` to make it publicly accessible. For private applications, you would need to adjust the deployment settings.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# --- Configuration ---
+# Google Cloud Project ID. Replace with your actual Project ID.
+PROJECT_ID=""
+# Name of the Cloud Run service.
+SERVICE_NAME="js-invaders"
+# Google Cloud region where the service will be deployed.
+REGION="us-central1"
+# Name of the Docker image.
+IMAGE_NAME="gcr.io/${PROJECT_ID}/${SERVICE_NAME}" # Using gcr.io, can be replaced with Artifact Registry path
+
+# --- Ensure Project ID is Set ---
+if [ -z "${PROJECT_ID}" ]; then
+    echo "Error: PROJECT_ID is not set. Please edit this script and set your Google Cloud Project ID."
+    # Attempt to get Project ID from gcloud config if not set in script
+    PROJECT_ID=$(gcloud config get-value project 2>/dev/null)
+    if [ -z "${PROJECT_ID}" ]; then
+        echo "Could not automatically determine Project ID. Please set it manually in the script or via 'gcloud config set project YOUR_PROJECT_ID'."
+        exit 1
+    else
+        echo "Using Project ID from gcloud config: ${PROJECT_ID}"
+        # Update IMAGE_NAME with the fetched PROJECT_ID
+        IMAGE_NAME="gcr.io/${PROJECT_ID}/${SERVICE_NAME}"
+    fi
+fi
+
+
+# --- Enable Necessary APIs ---
+echo "Enabling necessary Google Cloud services..."
+gcloud services enable run.googleapis.com     cloudbuild.googleapis.com     containerregistry.googleapis.com # Or artifactregistry.googleapis.com if you prefer
+
+# --- Build Docker Image using Google Cloud Build ---
+echo "Building Docker image with Google Cloud Build..."
+# The source for the build is the current directory '.'
+# The image will be tagged with the IMAGE_NAME
+gcloud builds submit --tag "${IMAGE_NAME}" .
+
+# --- Deploy to Google Cloud Run ---
+echo "Deploying image to Google Cloud Run..."
+gcloud run deploy "${SERVICE_NAME}" \
+    --image "${IMAGE_NAME}" \
+    --region "${REGION}" \
+    --platform "managed" \
+    --allow-unauthenticated \
+    --project "${PROJECT_ID}" \
+    --quiet
+
+#    --port 8080 # Not needed if Gunicorn uses $PORT from environment
+
+SERVICE_URL=$(gcloud run services describe "${SERVICE_NAME}" --platform managed --region "${REGION}" --format 'value(status.url)' --project "${PROJECT_ID}")
+
+echo ""
+echo "${SERVICE_NAME} deployed successfully!"
+echo "Service URL: ${SERVICE_URL}"
+echo ""
+echo "Note: If this is the first deployment, it might take a few minutes for the service to become fully available."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+gunicorn


### PR DESCRIPTION
This commit introduces files and scripts to enable deployment of the JS Invaders Flask application to Google Cloud Run.

Key additions and changes:

1.  **`requirements.txt`**:
    *   Added `gunicorn` as a dependency for serving the Flask app in a production WSGI environment.

2.  **`Dockerfile`**:
    *   Created a `Dockerfile` to containerize the application. It uses a Python 3.9 slim base image, installs dependencies from `requirements.txt`, copies the application code, and sets `gunicorn` as the entry point, configured to listen on the port specified by the `PORT` environment variable provided by Cloud Run.

3.  **`.gcloudignore`**:
    *   Added a `.gcloudignore` file to specify files and directories (e.g., `venv/`, `__pycache__/`, `.git/`) that should be excluded when uploading the source to Google Cloud for builds.

4.  **`deploy.sh`**:
    *   Created a shell script (`deploy.sh`) to automate the deployment process. This script:
        *   Prompts for or attempts to auto-detect the Google Cloud `PROJECT_ID`.
        *   Enables necessary Google Cloud APIs (Cloud Run, Cloud Build, Container Registry).
        *   Uses `gcloud builds submit` to build the Docker image with Google Cloud Build and push it to Google Container Registry.
        *   Uses `gcloud run deploy` to deploy the built image to Cloud Run, allowing unauthenticated access.
        *   Outputs the URL of the deployed service.

5.  **`README.md`**:
    *   Updated with a new section detailing prerequisites and step-by-step instructions for deploying the application to Google Cloud Run using the `deploy.sh` script.

These changes provide a streamlined path for deploying the application to a scalable, serverless environment on Google Cloud.